### PR TITLE
Added implementation for testing

### DIFF
--- a/commerce_sendcloud.admin.inc
+++ b/commerce_sendcloud.admin.inc
@@ -62,6 +62,9 @@ function commerce_sendcloud_admin_form($form, &$form_state) {
   $form['tab2']['commerce_sendcloud_testmode'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable testmode'),
+    '#description' => t('Enables test-mode. Because of API limitations, this means setting the shipping method to 
+        <strong>Unstamped Letter</strong>, the only shipping method that does not require payment information. After
+        sending a test, you should delete the parcel from the SendCloud control panel manually!'),
     '#default_value' => variable_get('commerce_sendcloud_testmode', '1'),
   );
 

--- a/commerce_sendcloud.module
+++ b/commerce_sendcloud.module
@@ -373,6 +373,10 @@ function commerce_sendcloud_create_label($order) {
         if (!empty($value->data['shipping_service']['data']['sendcloud_type'])) {
           // Set the id for easy usage.
           $sendcloud_method_id = $value->data['shipping_service']['data']['sendcloud_type'];
+          if (variable_get('commerce_sendcloud_testmode') == 1) {
+            //@TODO : this is hardcoded ATM, devise proper way to obtain this id.
+            $sendcloud_method_id = 8;
+          }
           // Set the docall var.
           $docall = FALSE;
           // Set the update var.
@@ -399,7 +403,6 @@ function commerce_sendcloud_create_label($order) {
           if ($docall) {
             // Approach the api.
             $sendcloud_api = new SendcloudApi(
-              'live',
               variable_get('commerce_sendcloud_key'),
               variable_get('commerce_sendcloud_secret')
             );


### PR DESCRIPTION
Adding first implementation of test mode. 

If checked, this will change the shipping method to id = 8 , which is Unstamped Letter : momentarily the only shipping method that does not require payment, and is thus safe to use for testing.
